### PR TITLE
Fix `tsconfigRootDir`.

### DIFF
--- a/config/typescript-overrides.js
+++ b/config/typescript-overrides.js
@@ -12,7 +12,8 @@ module.exports = {
 			jsx: true,
 		},
 		project: 'tsconfig.json',
-		tsconfigRootDir: '.',
+		projectService: true,
+		tsconfigRootDir: __dirname,
 	},
 	rules: {
 		'prefer-const': ['error', { destructuring: 'all' }],


### PR DESCRIPTION
According to
https://typescript-eslint.io/getting-started/typed-linting/ (Legacy Config). Unlocks web-scrobbler/web-scrobbler#5597 and successors.
